### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/add-comment-for-help-wanted_ci.yml
+++ b/.github/workflows/add-comment-for-help-wanted_ci.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
     steps:
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.2.1
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4.0.2
         with:
           path: |
             ~/.gradle/caches
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleDebug
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: Signed app bundle
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.2.1
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4.0.2
         with:
           path: |
             ~/.gradle/caches
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleDebug
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: Signed app bundle
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.2.1
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4.0.2
         with:
           path: |
             ~/.gradle/caches
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleDebug
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: Signed app bundle
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.2.1
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4.0.2
         with:
           path: |
             ~/.gradle/caches
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleRelease
 
       - name: Sign APK
-        uses: ilharp/sign-android-release@v1
+        uses: ilharp/sign-android-release@v1.0.4
         # ID used to access action output
         id: sign_app
         with:
@@ -51,7 +51,7 @@ jobs:
           buildToolsVersion: 33.0.0
 
       - name: Release to GitHub
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@2.9.0
         with:
           repo_token: ${{ secrets.GIT_BOT_TOKEN }}
           file: ${{steps.sign_app.outputs.signedFile}}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GIT_BOT_TOKEN }}
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v3.2.0
         with:
           config: cliff.toml
           args: --verbose
@@ -28,7 +28,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v2
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true

--- a/.github/workflows/close-inactive-issues_ci.yml
+++ b/.github/workflows/close-inactive-issues_ci.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v9.0.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/delete-unused-caches_ci.yml
+++ b/.github/workflows/delete-unused-caches_ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Do other steps like checkout, install, compile, etc.
-      - uses: MyAlbum/purge-cache@master
+      - uses: MyAlbum/purge-cache@v2.1.0
         with:
           max-age: 1800 # Cache max 7 days since last use (this is the default)
           debug: true # Set to true to output debug info

--- a/.github/workflows/gitguardian.yaml
+++ b/.github/workflows/gitguardian.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: GitGuardian scan
-        uses: GitGuardian/ggshield/actions/secret@v1.26.0
+        uses: GitGuardian/ggshield/actions/secret@v1.29.0
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}

--- a/.github/workflows/thank-you-issue_ci.yml
+++ b/.github/workflows/thank-you-issue_ci.yml
@@ -10,7 +10,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GIT_BOT_TOKEN }}
           script: |

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -14,7 +14,7 @@ jobs:
     name: Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v3.5.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v9.0.0](https://github.com/actions/stale/releases/tag/v9.0.0)** on 2023-12-07T12:30:54Z
* **[gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action)** published a new release **[v3.5.0](https://github.com/gradle/wrapper-validation-action/releases/tag/v3.5.0)** on 2024-07-15T19:31:50Z
* **[actions/github-script](https://github.com/actions/github-script)** published a new release **[v7.0.1](https://github.com/actions/github-script/releases/tag/v7.0.1)** on 2023-11-17T22:21:53Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.4](https://github.com/actions/upload-artifact/releases/tag/v4.3.4)** on 2024-07-05T15:15:04Z
* **[crazy-max/ghaction-import-gpg](https://github.com/crazy-max/ghaction-import-gpg)** published a new release **[v6.1.0](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.1.0)** on 2023-12-26T16:55:59Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[GitGuardian/ggshield](https://github.com/GitGuardian/ggshield)** published a new release **[v1.29.0](https://github.com/GitGuardian/ggshield/releases/tag/v1.29.0)** on 2024-06-25T12:41:51Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.1](https://github.com/actions/setup-java/releases/tag/v4.2.1)** on 2024-03-14T14:29:47Z
* **[peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)** published a new release **[v4.0.0](https://github.com/peter-evans/create-or-update-comment/releases/tag/v4.0.0)** on 2024-01-25T11:47:51Z
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v3.2.0](https://github.com/orhun/git-cliff-action/releases/tag/v3.2.0)** on 2024-06-03T13:15:28Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[MyAlbum/purge-cache](https://github.com/MyAlbum/purge-cache)** published a new release **[v2.1.0](https://github.com/MyAlbum/purge-cache/releases/tag/v2.1.0)** on 2023-07-31T07:02:57Z
* **[ilharp/sign-android-release](https://github.com/ilharp/sign-android-release)** published a new release **[v1.0.4](https://github.com/ilharp/sign-android-release/releases/tag/v1.0.4)** on 2022-10-25T17:14:28Z
* **[svenstaro/upload-release-action](https://github.com/svenstaro/upload-release-action)** published a new release **[2.9.0](https://github.com/svenstaro/upload-release-action/releases/tag/2.9.0)** on 2024-02-21T21:44:47Z
