### PR TITLE
Bugfix: Add ScrollView for reordering apps screen

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/mlauncher/ui/ReorderHomeAppsFragment.kt
+++ b/app/src/main/java/com/github/droidworksstudio/mlauncher/ui/ReorderHomeAppsFragment.kt
@@ -15,6 +15,8 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -118,14 +120,7 @@ class ReorderHomeAppsFragment : Fragment() {
             DragEvent.ACTION_DROP -> {
                 // Remove highlighting
                 targetView.background = null
-                return true
-            }
-            DragEvent.ACTION_DRAG_ENDED -> {
-                // Remove highlighting when the drag ends
-                targetView.background = null
-                return true
-            }
-            else -> {
+                
                 // Extract the dragged TextView
                 val draggedTextView = event.localState as TextView
 
@@ -134,8 +129,14 @@ class ReorderHomeAppsFragment : Fragment() {
                 val targetIndex = (targetView.parent as ViewGroup).indexOfChild(targetView)
                 reorderApps(draggedIndex, targetIndex)
 
-                return false
+                return true
             }
+            DragEvent.ACTION_DRAG_ENDED -> {
+                // Remove highlighting when the drag ends
+                targetView.background = null
+                return true
+            }
+            else -> return false
         }
     }
 
@@ -220,5 +221,8 @@ class ReorderHomeAppsFragment : Fragment() {
                 true
             }
         }
+
+        // Scroll to the top of the list after updating
+        (binding.homeAppsLayout.parent as? ScrollView)?.scrollTo(0, 0)
     }
 }

--- a/app/src/main/res/layout/fragment_reorder_home_apps.xml
+++ b/app/src/main/res/layout/fragment_reorder_home_apps.xml
@@ -18,7 +18,7 @@
     <LinearLayout
         android:id="@+id/pageLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_marginStart="24dp"
         android:layout_marginTop="56dp"
         android:layout_marginEnd="24dp"
@@ -34,15 +34,22 @@
             android:textSize="@dimen/date_size" />
 
         <!-- Home apps-->
-        <LinearLayout
-            android:id="@+id/homeAppsLayout"
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
-            android:orientation="vertical"
-            android:paddingHorizontal="20dp"
-            android:paddingBottom="80dp"
-            android:paddingTop="112dp" />
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <LinearLayout
+                android:id="@+id/homeAppsLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="vertical"
+                android:paddingHorizontal="20dp"
+                android:paddingBottom="80dp"
+                android:paddingTop="112dp" />
+
+        </ScrollView>
     </LinearLayout>
 
 </FrameLayout>


### PR DESCRIPTION
### Type of Change
- [X] Bug Fix (user-facing)

### All Submissions

- [X] Checked for existing [Pull Requests](../../../pulls) for the same update/change
- [X] Descriptive commit message with a short title
- [X] Self-reviewed code
- [X] Code comments, especially in complex areas
- [X] No new warnings or errors introduced
- [X] Changes made in a separate branch
- [X] Branch named with appropriate prefix (e.g., 'bug/', 'feat/', 'clean/', 'release/')

### Before Opening Pull Request

- [X] Descriptive title for your PR
- [X] Detailed description of changes

### Description of Changes

#### Changes Description

1. The current reorder app screen doesn't show the full app list when the number of apps is large (depending on screen size mobile device), therefore you cannot reorder apps that are below the screen size
2. Added Scrollview to the Reorder App Screen in order to be able to scroll down the page when the list of apps is large

### Test Device:
- mLauncher version: 1.6.7
- Device name: Pixel 7
- Android version: Android 14