### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4.0.2
+        uses: orhun/git-cliff-action@v4.1.0
         with:
           config: cliff.toml
           args: --verbose


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v4.1.0](https://github.com/orhun/git-cliff-action/releases/tag/v4.1.0)** on 2024-09-17T21:07:57Z
