### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.3.0
+        uses: actions/setup-java@v4.4.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.3.0
+        uses: actions/setup-java@v4.4.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.3.0
+        uses: actions/setup-java@v4.4.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.3.0
+        uses: actions/setup-java@v4.4.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4.1.0
+        uses: orhun/git-cliff-action@v4.3.0
         with:
           config: cliff.toml
           args: --verbose

--- a/.github/workflows/keep-workflow-packages-up-to-date.yml
+++ b/.github/workflows/keep-workflow-packages-up-to-date.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GIT_BOT_TOKEN }}

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -14,7 +14,7 @@ jobs:
     name: Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: gradle/wrapper-validation-action@v3.5.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.4.0](https://github.com/actions/setup-java/releases/tag/v4.4.0)** on 2024-09-24T14:04:01Z
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v4.3.0](https://github.com/orhun/git-cliff-action/releases/tag/v4.3.0)** on 2024-09-27T16:08:11Z
