### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-branch_ci.yml
+++ b/.github/workflows/android-branch_ci.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v4.2.2
+      - uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.gradle/caches
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleDebug
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: Signed app apk
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-main_ci.yml
+++ b/.github/workflows/android-main_ci.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v4.2.2
+      - uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.gradle/caches
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleDebug
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: Signed app apk
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-pr_ci.yml
+++ b/.github/workflows/android-pr_ci.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v4.2.2
+      - uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.gradle/caches
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean && ./gradlew assembleDebug
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: Signed app apk
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/cache@v4.2.2
+      - uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
