### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/android-release_ci.yml
+++ b/.github/workflows/android-release_ci.yml
@@ -52,7 +52,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Release to GitHub
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.10.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{steps.sign_app_apk.outputs.signedFile}}
@@ -61,7 +61,7 @@ jobs:
           overwrite: true
 
       - name: Upload ProGuard Mapping File
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.10.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: app/build/outputs/mapping/release/mapping.txt
@@ -82,7 +82,7 @@ jobs:
           buildToolsVersion: 35.0.0
 
       - name: Release to GitHub
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.10.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{steps.sign_app_aab.outputs.signedFile}}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[svenstaro/upload-release-action](https://github.com/svenstaro/upload-release-action)** published a new release **[2.10.0](https://github.com/svenstaro/upload-release-action/releases/tag/2.10.0)** on 2025-06-21T19:56:01Z
