### PR TITLE
Adjusted threshold values for Gestures & distance math in GestureManager (Closes #816)

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/mlauncher/data/Constants.kt
+++ b/app/src/main/java/com/github/droidworksstudio/mlauncher/data/Constants.kt
@@ -61,8 +61,8 @@ object Constants {
     const val MAX_THRESHOLD = 100 // pixels
     var SHORT_SWIPE_THRESHOLD = 0f  // pixels
     var LONG_SWIPE_THRESHOLD = 0f // pixels
-    var USR_DPIX = 0
-    var USR_DPIY = 0
+    var USR_DPIX = 0f
+    var USR_DPIY = 0f
 
 
     // Update MAX_HOME_PAGES dynamically based on MAX_HOME_APPS

--- a/app/src/main/java/com/github/droidworksstudio/mlauncher/data/Constants.kt
+++ b/app/src/main/java/com/github/droidworksstudio/mlauncher/data/Constants.kt
@@ -61,6 +61,8 @@ object Constants {
     const val MAX_THRESHOLD = 100 // pixels
     var SHORT_SWIPE_THRESHOLD = 0f  // pixels
     var LONG_SWIPE_THRESHOLD = 0f // pixels
+    var USR_DPIX = 0
+    var USR_DPIY = 0
 
 
     // Update MAX_HOME_PAGES dynamically based on MAX_HOME_APPS
@@ -94,8 +96,11 @@ object Constants {
         val prefs = Prefs(context)
         val metrics = context.resources.displayMetrics
 
-        val screenWidthInches = metrics.widthPixels / metrics.xdpi
-        val screenHeightInches = metrics.heightPixels / metrics.ydpi
+        USR_DPIX = metrics.xdpi
+        USR_DPIY = metrics.ydpi
+
+        val screenWidthInches = metrics.widthPixels / USR_DPIX
+        val screenHeightInches = metrics.heightPixels / USR_DPIY
 
         if (direction.equals("left", true) || direction.equals("right", true)) {
             LONG_SWIPE_THRESHOLD = screenWidthInches * prefs.longSwipeThreshold

--- a/app/src/main/java/com/github/droidworksstudio/mlauncher/data/Prefs.kt
+++ b/app/src/main/java/com/github/droidworksstudio/mlauncher/data/Prefs.kt
@@ -338,13 +338,13 @@ class Prefs(val context: Context) {
         get() = getSetting(FILTER_STRENGTH, 25)
         set(value) = prefsNormal.edit { putInt(FILTER_STRENGTH, value) }
 
-    var shortSwipeThreshold: Int
-        get() = getSetting(SHORT_SWIPE_THRESHOLD, 25)
-        set(value) = prefsNormal.edit { putInt(SHORT_SWIPE_THRESHOLD, value) }
+    var shortSwipeThreshold: Float
+        get() = getSetting(SHORT_SWIPE_THRESHOLD, 0.25f)
+        set(value) = prefsNormal.edit { putFloat(SHORT_SWIPE_THRESHOLD, value) }
 
-    var longSwipeThreshold: Int
-        get() = getSetting(LONG_SWIPE_THRESHOLD, 65)
-        set(value) = prefsNormal.edit { putInt(LONG_SWIPE_THRESHOLD, value) }
+    var longSwipeThreshold: Float
+        get() = getSetting(LONG_SWIPE_THRESHOLD, 0.55f)
+        set(value) = prefsNormal.edit { putFloat(LONG_SWIPE_THRESHOLD, value) }
 
     var searchFromStart: Boolean
         get() = getSetting(SEARCH_START, false)

--- a/app/src/main/java/com/github/droidworksstudio/mlauncher/listener/GestureManager.kt
+++ b/app/src/main/java/com/github/droidworksstudio/mlauncher/listener/GestureManager.kt
@@ -134,7 +134,7 @@ class GestureManager(
         val longThreshold = Constants.LONG_SWIPE_THRESHOLD
         val velocityThreshold = Constants.SWIPE_VELOCITY_THRESHOLD
 
-        val distance = if (isHorizontalSwipe) abs(diffX) else abs(diffY)
+        val distance = if (isHorizontalSwipe) (abs(diffX)/Constants.USR_DPIX) else (abs(diffY)/Constants.USR_DPIY)
         val isLongSwipe = distance > longThreshold
         val isShortSwipe = distance in (shortThreshold + 1)..longThreshold
 

--- a/app/src/main/java/com/github/droidworksstudio/mlauncher/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/github/droidworksstudio/mlauncher/ui/SettingsFragment.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -306,8 +307,8 @@ class SettingsFragment : Fragment() {
         var toggledSettingsLocked by remember { mutableStateOf(prefs.settingsLocked) }
         var toggledLockOrientation by remember { mutableStateOf(prefs.lockOrientation) }
 
-        var selectedShortSwipeThreshold by remember { mutableIntStateOf(prefs.shortSwipeThreshold) }
-        var selectedLongSwipeThreshold by remember { mutableIntStateOf(prefs.longSwipeThreshold) }
+        var selectedShortSwipeThreshold by remember { mutableFloatStateOf(prefs.shortSwipeThreshold) }
+        var selectedLongSwipeThreshold by remember { mutableFloatStateOf(prefs.longSwipeThreshold) }
 
         val contextMenuOptionLabels = listOf(
             getLocalizedString(R.string.pin),
@@ -2079,8 +2080,8 @@ class SettingsFragment : Fragment() {
                                 maxValue = selectedLongSwipeThreshold,
                                 currentValue = prefs.shortSwipeThreshold,
                                 onValueSelected = { newSettingsSize ->
-                                    selectedShortSwipeThreshold = newSettingsSize.toInt()
-                                    prefs.shortSwipeThreshold = newSettingsSize.toInt()
+                                    selectedShortSwipeThreshold = newSettingsSize.toFloat()
+                                    prefs.shortSwipeThreshold = newSettingsSize.toFloat()
                                 }
                             )
                         }
@@ -2098,8 +2099,8 @@ class SettingsFragment : Fragment() {
                                 maxValue = Constants.MAX_THRESHOLD,
                                 currentValue = prefs.longSwipeThreshold,
                                 onValueSelected = { newSettingsSize ->
-                                    selectedLongSwipeThreshold = newSettingsSize.toInt()
-                                    prefs.longSwipeThreshold = newSettingsSize.toInt()
+                                    selectedLongSwipeThreshold = newSettingsSize.toFloat()
+                                    prefs.longSwipeThreshold = newSettingsSize.toFloat()
                                 }
                             )
                         }


### PR DESCRIPTION
### Type of Change

- [X] Bug Fix

### Summary of Changes

Closes #816 

Reasoning for rolling back gesture threshold values from int to float: the new Swipe Gesture math was introduced to be more flexible in terms of device sizes. mlauncher now is supposed to react to inches. Adding pixel-based preferences to the base calculation does not follow through with this approach. Hence, a float-based solution is re-implemented.

#### Key Changes

1. rolled back changes made in 0cdaa9b regarding threshold types: from int back to float
2. added device DPI values to Constants
3. GestureManager now calculates distance with user DPI for gesture checks instead of pixel values
4. Changed default swipe gesture thresholds (opinionated)

---

### Test Information <!-- Required -->

- **MultiLauncher Version: 1.10.7.8**
- **Device Name: Google Pixel 7A**
- **Android Version: 15**
- **Other Notes: Tested locally with AS**
